### PR TITLE
Bug fix: addProject - no_owner defaults to true only on undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -205,7 +205,7 @@ pivotal.getProject = function (projectId, cb) {
 */
 pivotal.addProject = function (projectData, cb) {
 
-    if (!projectData.no_owner) {
+    if (typeof projectData.no_owner === 'undefined') {
         projectData.no_owner = true;
     }
 


### PR DESCRIPTION
``` javascript
if (!projectData.no_owner) {
        projectData.no_owner = true;
    }
```

This turns `false` into `true`
- This patch fixes this issue by using `typeof` instead
