### PR TITLE
Bug fix: no_owner (addProject) requires a type to be provided as part of the xml

### DIFF
--- a/index.js
+++ b/index.js
@@ -876,7 +876,12 @@ pivotal.toXml = function (data) {
 
     var ret = "",
         val = null,
-        d   = null;
+        d   = null,
+        t   = '';
+
+    var fieldTypes = {
+        'no_owner': 'type=\"boolean\"'
+    }
 
     for(d in data){
         if (data.hasOwnProperty(d)) {
@@ -887,7 +892,10 @@ pivotal.toXml = function (data) {
                     val = sanitize(data[d].toString()).entityEncode();
             }
 
-            ret += "<" + d + ">" + val + "</" + d + ">";
+            if (fieldTypes[d] !== undefined)
+                t = fieldTypes[d]
+
+            ret += "<" + d + ' ' + t + ">" + val + "</" + d + ">";
         }
     }
 


### PR DESCRIPTION
no_owner requires the xml element to look like this:

``` xml
<no_owner type=\"boolean\">false</no_owner>
```

This patch, adds the ```type=\"boolean\" for no_owner; and lays groundwork for others that require this type attribute.

Probably a neater way to do it, but this fixes the bug.
