### PR TITLE
getCurrentBacklogIterations bug with node 0.10

### DIFF
--- a/index.js
+++ b/index.js
@@ -393,7 +393,7 @@ pivotal.getBacklogIterations = function (projectId, filters, cb) {
 */
 pivotal.getCurrentBacklogIterations = function (projectId, cb) {
 
-    pivotal.apiCall("GET", url, { group: "current_backlog" }, null, null, cb);
+    pivotal.apiCall("GET", ["projects", projectId, "iterations"], { group: "current_backlog" }, null, null, cb);
 };
 
 /**


### PR DESCRIPTION
in node 0.10.\* this method was cousing an error saying "no .join method on #<object>" this is the fix
