### PR TITLE
fixed content-length in case data contain multi-byte characters

### DIFF
--- a/index.js
+++ b/index.js
@@ -756,7 +756,7 @@ pivotal.apiCall = function (method, pathSegments, query, data, file, cb) {
             options.headers["Content-Type"]   = "application/xml";
         }
 
-        options.headers["Content-Length"] = postData.length;
+        options.headers["Content-Length"] = Buffer.byteLength(postData, 'utf8');
     }
 
     if (file) {
@@ -767,10 +767,10 @@ pivotal.apiCall = function (method, pathSegments, query, data, file, cb) {
             options.headers["Content-Length"]   = fs.statSync(file.path).size;
         }
         else {
-            options.headers["Content-Length"]   = file.data.length;
+            options.headers["Content-Length"]   = Buffer.byteLength(file.data, 'utf8');
         }
 
-        options.headers["Content-Length"]   += 196 + file.name.length;
+        options.headers["Content-Length"]   += 196 + Buffer.byteLength(file.name, 'utf8');
 
         options.headers.Expect = "100-continue";
         options.headers["Content-Type"]         = "multipart/form-data; boundary=----------------------------" + boundaryKey;


### PR DESCRIPTION
Calling addStory with data containing multi-byte characters (e.g. Japanese) fails in HTTP 400 status.
String.length is not preferable because it does not match encoded length in bytes in those cases.

Please refer to this question for more information.
http://stackoverflow.com/questions/9864662/how-to-get-the-string-length-in-bytes-in-nodejs
